### PR TITLE
[Security] Added secure key for key and secret rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env


### PR DESCRIPTION

I want to run production on my local machine, but was running into the following error,
```
ArgumentError: Missing `secret_key_base` for 'production' environment, set this string with `rails credentials:edit`
```

From this stack overflow [thread](https://stackoverflow.com/questions/51466887/rails-how-to-fix-missing-secret-key-base-for-production-environment), I learn the error was because i didn't have the secret key stored.

This is the work needed to export the `secret_key_base` env var to production (locally?).

Followed the heroku tutorial on [secure key](https://devcenter.heroku.com/articles/securekey), which walks you through how to install secure-key on the heroku instance and have the same secret locally for your dev environment. 

**What is secure key?** 
Secure Key is an add-on for providing automatic and graceful key rotation.

Part of the work for issue #36 

